### PR TITLE
mfd: usbio: gpio read payload reduces 4 bytes

### DIFF
--- a/include/linux/mfd/usbio.h
+++ b/include/linux/mfd/usbio.h
@@ -35,6 +35,8 @@ struct usbio_platform_data {
 	};
 };
 
+extern char *gpio_hids[];
+
 typedef void (*usbio_event_cb_t)(struct platform_device *pdev, u8 cmd,
 				const void *evt_data, int len);
 
@@ -45,5 +47,6 @@ int usbio_transfer(struct platform_device *pdev, u8 cmd, const void *obuf,
 		  int obuf_len, void *ibuf, int *ibuf_len);
 int usbio_transfer_noack(struct platform_device *pdev, u8 cmd, const void *obuf,
 			int obuf_len);
+bool is_gpio_hid_v1_0(const char *pnpid);
 
 #endif


### PR DESCRIPTION
Following the vision driver protocol, the payload length for gpio read needs to be reduced by 4 bytes because the value field doesn't need to be sent in the request.