### PR TITLE
gpio: gpio-usbio: change return type from int to void

### DIFF
--- a/drivers/gpio/gpio-usbio.c
+++ b/drivers/gpio/gpio-usbio.c
@@ -17,6 +17,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 #include <linux/bitops.h>
+#include <linux/version.h>
 
 #define GPIO_PAYLOAD_LEN(packet, pin)	(sizeof(*packet))
 
@@ -476,9 +477,15 @@ static int usbio_gpio_probe(struct platform_device *pdev)
 	return devm_gpiochip_add_data(&pdev->dev, &usbio_gpio->gc, usbio_gpio);
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int usbio_gpio_remove(struct platform_device *pdev)
+#else
+static void usbio_gpio_remove(struct platform_device *pdev)
+#endif
 {
-	return 0;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
+       return 0;
+#endif
 }
 
 static struct platform_driver usbio_gpio_driver = {

--- a/drivers/i2c/busses/i2c-usbio.c
+++ b/drivers/i2c/busses/i2c-usbio.c
@@ -400,13 +400,18 @@ static int usbio_i2c_probe(struct platform_device *pdev)
 	return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int usbio_i2c_remove(struct platform_device *pdev)
+#else
+static void usbio_i2c_remove(struct platform_device *pdev)
+#endif
 {
 	struct usbio_i2c_dev *usbio_i2c = platform_get_drvdata(pdev);
 
 	i2c_del_adapter(&usbio_i2c->adap);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static struct platform_driver usbio_i2c_driver = {


### PR DESCRIPTION
Kernel 6.11 has changed the platform_driver::remove return type from integer to void.                                           