### PR TITLE
gpio: gpio-usbio: change return type from int to void

### DIFF
--- a/drivers/gpio/gpio-usbio.c
+++ b/drivers/gpio/gpio-usbio.c
@@ -17,6 +17,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 #include <linux/bitops.h>
+#include <linux/version.h>
 
 #define GPIO_PAYLOAD_LEN(packet, pin)	(sizeof(*packet))
 
@@ -489,9 +490,15 @@ static int usbio_gpio_probe(struct platform_device *pdev)
 	return devm_gpiochip_add_data(&pdev->dev, &usbio_gpio->gc, usbio_gpio);
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int usbio_gpio_remove(struct platform_device *pdev)
+#else
+static void usbio_gpio_remove(struct platform_device *pdev)
+#endif
 {
-	return 0;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
+       return 0;
+#endif
 }
 
 static struct platform_driver usbio_gpio_driver = {

--- a/drivers/gpio/gpio-usbio.c
+++ b/drivers/gpio/gpio-usbio.c
@@ -11,6 +11,7 @@
 #include <linux/kernel.h>
 #include <linux/kref.h>
 #include <linux/mfd/usbio.h>
+#include <linux/mfd/core.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
 #include <linux/slab.h>
@@ -126,9 +127,22 @@ static int usbio_gpio_read(struct usbio_gpio_dev *usbio_gpio, u8 gpio_id)
 	packet->bankid = gpio_id / GPIO_PER_BANK;
 	packet->pincount = 1;
 	packet->pins = gpio_id % GPIO_PER_BANK;
-	ret = usbio_transfer(usbio_gpio->pdev, GPIO_READ, packet,
+
+	/*
+	 * for GPIO_READ, the [u32 value;] field in gpio_rw_packet is not used
+	 * Therefore, reduce the payload length by 4 bytes.
+	 */
+
+	if (usbio_gpio->pdev->mfd_cell &&
+	    is_gpio_hid_v1_0(usbio_gpio->pdev->mfd_cell->acpi_match->pnpid)) {
+		ret = usbio_transfer(usbio_gpio->pdev, GPIO_READ, packet,
+			    GPIO_PAYLOAD_LEN(packet, packet->pins) - sizeof(u32),
+			    usbio_gpio->ibuf, &ibuf_len);
+	} else {
+		ret = usbio_transfer(usbio_gpio->pdev, GPIO_READ, packet,
 			    GPIO_PAYLOAD_LEN(packet, packet->pins),
 			    usbio_gpio->ibuf, &ibuf_len);
+	}
 
 	ack_packet = (struct gpio_rw_packet *)usbio_gpio->ibuf;
 	if (ret || !ibuf_len || ack_packet->pins != packet->pins) {

--- a/drivers/i2c/busses/i2c-usbio.c
+++ b/drivers/i2c/busses/i2c-usbio.c
@@ -399,13 +399,18 @@ static int usbio_i2c_probe(struct platform_device *pdev)
 	return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int usbio_i2c_remove(struct platform_device *pdev)
+#else
+static void usbio_i2c_remove(struct platform_device *pdev)
+#endif
 {
 	struct usbio_i2c_dev *usbio_i2c = platform_get_drvdata(pdev);
 
 	i2c_del_adapter(&usbio_i2c->adap);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static struct platform_driver usbio_i2c_driver = {

--- a/drivers/mfd/usbio.c
+++ b/drivers/mfd/usbio.c
@@ -20,7 +20,10 @@
 
 #include "bridge.h"
 
-static char *gpio_hids[] = {
+#define GPIO_V1_0_START_IDX 4
+#define GPIO_V1_0_END_IDX 4
+
+char *gpio_hids[] = {
 	"INTC1074", /* TGL */
 	"INTC1096", /* ADL */
 	"INTC100B", /* RPL */
@@ -98,6 +101,18 @@ static int precheck_acpi_hid(struct usb_interface *intf)
 
 	return 0;
 }
+
+bool is_gpio_hid_v1_0(const char *pnpid)
+{
+	int i;
+
+	for (i = GPIO_V1_0_START_IDX; i <= GPIO_V1_0_END_IDX; i++) {
+		if (strcmp(pnpid, gpio_hids[i]) == 0)
+			return true;
+	}
+	return false;
+}
+EXPORT_SYMBOL_GPL(is_gpio_hid_v1_0);
 
 static bool usbio_validate(void *data, u32 data_len)
 {
@@ -230,9 +245,22 @@ static int usbio_control_xfer(struct usbio_stub *stub, u8 cmd, const void *obuf,
 	stub->ipacket.ibuf = ibuf;
 	stub->acked = false;
 	usb_autopm_get_interface(bridge->intf);
-	ret = usb_control_msg_send(bridge->udev, bridge->ep0, 0,
+
+	/*
+	 * The host sent IO commands that reduce by 4 bytes
+	 * for GPIO read operations on v1.0
+	 */
+
+	if (stub->type ==  GPIO_STUB && is_gpio_hid_v1_0(bridge->cells->acpi_match->pnpid)) {
+		ret = usb_control_msg_send(bridge->udev, bridge->ep0, 0,
+			USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_DIR_OUT, 0, 0,
+			header, actual - 4, timeout, GFP_KERNEL);
+	} else {
+		ret = usb_control_msg_send(bridge->udev, bridge->ep0, 0,
 			USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_DIR_OUT, 0, 0,
 			header, actual, timeout, GFP_KERNEL);
+	}
+
 	if (ret) {
 		dev_err(&bridge->intf->dev,
 			"bridge write failed ret:%d total_len:%d\n ", ret,

--- a/include/linux/mfd/usbio.h
+++ b/include/linux/mfd/usbio.h
@@ -35,6 +35,8 @@ struct usbio_platform_data {
 	};
 };
 
+extern char *gpio_hids[];
+
 typedef void (*usbio_event_cb_t)(struct platform_device *pdev, u8 cmd,
 				const void *evt_data, int len);
 
@@ -45,5 +47,6 @@ int usbio_transfer(struct platform_device *pdev, u8 cmd, const void *obuf,
 		  int obuf_len, void *ibuf, int *ibuf_len);
 int usbio_transfer_noack(struct platform_device *pdev, u8 cmd, const void *obuf,
 			int obuf_len);
+bool is_gpio_hid_v1_0(const char *pnpid);
 
 #endif


### PR DESCRIPTION
Kernel 6.11 has changed the platform_driver::remove return type from integer to void.