### PR TITLE
gpio: gpio-usbio: modify modalias

### DIFF
--- a/drivers/gpio/gpio-usbio.c
+++ b/drivers/gpio/gpio-usbio.c
@@ -514,4 +514,4 @@ MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
 MODULE_AUTHOR("Lifu Wang <lifu.wang@intel.com>");
 MODULE_DESCRIPTION("Intel USBIO-GPIO driver");
 MODULE_LICENSE("GPL v2");
-MODULE_ALIAS("platform:usb-gpio");
+MODULE_ALIAS("platform:usbio-gpio");

--- a/drivers/gpio/gpio-usbio.c
+++ b/drivers/gpio/gpio-usbio.c
@@ -497,7 +497,7 @@ static void usbio_gpio_remove(struct platform_device *pdev)
 #endif
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
-       return 0;
+	return 0;
 #endif
 }
 
@@ -511,6 +511,7 @@ module_platform_driver(usbio_gpio_driver);
 
 MODULE_AUTHOR("Zhang Lixu <lixu.zhang@intel.com>");
 MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
+MODULE_AUTHOR("Lifu Wang <lifu.wang@intel.com>");
 MODULE_DESCRIPTION("Intel USBIO-GPIO driver");
 MODULE_LICENSE("GPL v2");
 MODULE_ALIAS("platform:usb-gpio");

--- a/drivers/i2c/busses/i2c-usbio.c
+++ b/drivers/i2c/busses/i2c-usbio.c
@@ -408,6 +408,7 @@ static void usbio_i2c_remove(struct platform_device *pdev)
 	struct usbio_i2c_dev *usbio_i2c = platform_get_drvdata(pdev);
 
 	i2c_del_adapter(&usbio_i2c->adap);
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
 #endif
@@ -424,6 +425,7 @@ module_platform_driver(usbio_i2c_driver);
 MODULE_AUTHOR("Ye Xiang <xiang.ye@intel.com>");
 MODULE_AUTHOR("Zhang Lixu <lixu.zhang@intel.com>");
 MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
+MODULE_AUTHOR("Lifu Wang <lifu.wang@intel.com>");
 MODULE_DESCRIPTION("Intel USBIO-I2C driver");
 MODULE_LICENSE("GPL v2");
 MODULE_ALIAS("platform:usb-i2c");

--- a/drivers/i2c/busses/i2c-usbio.c
+++ b/drivers/i2c/busses/i2c-usbio.c
@@ -428,4 +428,4 @@ MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
 MODULE_AUTHOR("Lifu Wang <lifu.wang@intel.com>");
 MODULE_DESCRIPTION("Intel USBIO-I2C driver");
 MODULE_LICENSE("GPL v2");
-MODULE_ALIAS("platform:usb-i2c");
+MODULE_ALIAS("platform:usbio-i2c");

--- a/drivers/mfd/usbio.c
+++ b/drivers/mfd/usbio.c
@@ -27,7 +27,8 @@ char *gpio_hids[] = {
 	"INTC1074", /* TGL */
 	"INTC1096", /* ADL */
 	"INTC100B", /* RPL */
-	"INTC10D1", /* MTL */
+	"INTC10D1", /* MTL-CVF */
+	"INTC1007", /* MTL */
 	"INTC10B5", /* LNL */
 };
 static struct mfd_cell_acpi_match usbio_acpi_match_gpio;
@@ -36,7 +37,8 @@ static char *i2c_hids[] = {
 	"INTC1075", /* TGL */
 	"INTC1097", /* ADL */
 	"INTC100C", /* RPL */
-	"INTC10D2", /* MTL */
+	"INTC10D2", /* MTL-CVF */
+	"INTC1008", /* MTL */
 	"INTC10B6", /* LNL */
 };
 static struct mfd_cell_acpi_match usbio_acpi_match_i2cs;
@@ -121,7 +123,7 @@ static bool usbio_validate(void *data, u32 data_len)
 	return (header->len + sizeof(*header) == data_len);
 }
 
-void usbio_dump(struct usbio_dev *bridge, void *buf, int len)
+static void usbio_dump(struct usbio_dev *bridge, void *buf, int len)
 {
 	int i;
 	u8 tmp[256] = { 0 };
@@ -1177,5 +1179,6 @@ module_usb_driver(usbbridge_driver);
 MODULE_AUTHOR("Ye Xiang <xiang.ye@intel.com>");
 MODULE_AUTHOR("Zhang Lixu <lixu.zhang@intel.com>");
 MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
+MODULE_AUTHOR("Lifu Wang <lifu.wang@intel.com>");
 MODULE_DESCRIPTION("Intel USBIO Bridge driver");
 MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Updating the modalias of usbio to ensure the udev can obtain the
correct information through uevent.
The system will automatically load the kernel module.