### PR TITLE
usbio: Fix GPIO and I2C driver modaliases

### DIFF
--- a/drivers/gpio/gpio-usbio.c
+++ b/drivers/gpio/gpio-usbio.c
@@ -499,4 +499,4 @@ MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
 MODULE_AUTHOR("Lifu Wang <lifu.wang@intel.com>");
 MODULE_DESCRIPTION("Intel USBIO-GPIO driver");
 MODULE_LICENSE("GPL v2");
-MODULE_ALIAS("platform:usb-gpio");
+MODULE_ALIAS("platform:usbio-gpio");

--- a/drivers/i2c/busses/i2c-usbio.c
+++ b/drivers/i2c/busses/i2c-usbio.c
@@ -437,4 +437,4 @@ MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
 MODULE_AUTHOR("Lifu Wang <lifu.wang@intel.com>");
 MODULE_DESCRIPTION("Intel USBIO-I2C driver");
 MODULE_LICENSE("GPL v2");
-MODULE_ALIAS("platform:usb-i2c");
+MODULE_ALIAS("platform:usbio-i2c");


### PR DESCRIPTION
The created GPIO and I2C devices have modaliases of "platform:usbio-gpio" and "platform:usbio-i2c" note "usbio" not "usb" fix the aliases of the drivers so that these will properly auto load.