### PR TITLE
Fix usbio I2C max transfer size

### DIFF
--- a/drivers/i2c/busses/i2c-usbio.c
+++ b/drivers/i2c/busses/i2c-usbio.c
@@ -65,7 +65,15 @@ struct i2c_xfer {
 	u8 data[];
 } __packed;
 
-#define USBIO_I2C_MAX_XFER_SIZE 256
+//[WA]: Max USB packet size needs to be 63
+//in order for fw download to work
+#define USBIO_MAX_PACKET_SIZE    63
+#define USBIO_BULK_MSG_HDR_SIZE   5
+
+#define USBIO_I2C_MAX_XFER_SIZE                            \
+	(USBIO_MAX_PACKET_SIZE - USBIO_BULK_MSG_HDR_SIZE - \
+	 sizeof(struct i2c_rw_packet))
+
 #define USBIO_I2C_BUF_SIZE                                                      \
 	(USBIO_I2C_MAX_XFER_SIZE + sizeof(struct i2c_rw_packet))
 
@@ -384,6 +392,7 @@ static int usbio_i2c_probe(struct platform_device *pdev)
 	usbio_i2c->adap.owner = THIS_MODULE;
 	usbio_i2c->adap.class = I2C_CLASS_HWMON;
 	usbio_i2c->adap.algo = &usbio_i2c_algo;
+	usbio_i2c->adap.quirks = &usbio_i2c_quirks;
 	usbio_i2c->adap.dev.parent = &pdev->dev;
 
 	try_bind_acpi(pdev, usbio_i2c);

--- a/drivers/mfd/usbio.c
+++ b/drivers/mfd/usbio.c
@@ -390,37 +390,8 @@ static int usbio_transfer_internal(struct platform_device *pdev, u8 cmd,
 		ret = usbio_control_xfer(stub, cmd, obuf, obuf_len,
 			ibuf, ibuf_len,	wait_ack, USB_WRITE_ACK_TIMEOUT);
 	else if (stub->type == I2C_STUB) {
-		if (cmd == I2C_WRITE) {
-			u8 *i2cpkt = obuf;
-			int wsize = 0;
-			bool done = false;
-			while (wsize < obuf_len) {
-				int chunk;
-
-				if ((obuf_len - wsize) <= MAX_PAYLOAD_BSIZE) {
-					chunk = obuf_len - wsize;
-					done = true;
-				} else
-					chunk = MAX_PAYLOAD_BSIZE;
-
-				//[WA]: The I2C header in each chunk has to be updated
-				//to the payload bytes being sent in that chunk for fw
-				//download to work.
-				struct i2c_rw_packet *i2cpkt_hdr = (struct i2c_rw_packet *)i2cpkt;
-				i2cpkt_hdr->len = chunk - sizeof(struct i2c_rw_packet);
-				
-				ret = usbio_bulk_write(stub, cmd, i2cpkt, chunk, ibuf, ibuf_len,
-						done, done? wait_ack : false, USB_WRITE_ACK_TIMEOUT);
-				if (ret || done)
-					break;
-
-				wsize += chunk - sizeof(struct i2c_rw_packet);
-				i2cpkt += chunk - sizeof(struct i2c_rw_packet);
-				memcpy(i2cpkt, obuf, sizeof(struct i2c_rw_packet));
-			}
-		} else
-			ret = usbio_bulk_write(stub, cmd, obuf, obuf_len,
-					ibuf, ibuf_len,	true, wait_ack, USB_WRITE_ACK_TIMEOUT);
+		ret = usbio_bulk_write(stub, cmd, obuf, obuf_len,
+			ibuf, ibuf_len, true, wait_ack, USB_WRITE_ACK_TIMEOUT);
 	}
 
 	return ret;

--- a/drivers/mfd/usbio.c
+++ b/drivers/mfd/usbio.c
@@ -303,7 +303,7 @@ static int usbio_bulk_write(struct usbio_stub *stub, u8 cmd, const void *obuf,
 	if (bridge->state == BRIDGE_STOPPED)
 		return -ENODEV;
 
-	if (obuf_len > MAX_PAYLOAD_SIZE)
+	if (obuf_len > MAX_PAYLOAD_BSIZE)
 		return -EINVAL;
 
 	if (last_pkt)


### PR DESCRIPTION
There are 2 issues with the I2C max transfer size in the i2c-usbio module:

1. The code defines a usbio_i2c_quirks struct but does not set
i2c_adapter.quirks. This causes ov08x40_burst_fill_regs() to not split
i2c-transfers larger then USBIO_I2C_MAX_XFER_SIZE which causes them
to be rejected with -EINVAL. Fix this by setting i2c_adapter.quirks.

2. Once 1. is fixed the following error messages show up in dmesg:

```
Jan 28 18:31:04 x1 kernel: usbio-bridge 3-9:1.0: data not correct header->len:5 payload_len:3
Jan 28 18:31:04 x1 kernel: usbio-bridge 3-9:1.0: data not correct header->len:5 payload_len:3
...
```

Every time ov08x40_burst_fill_regs() gets called. This is caused by
the usbio_transfer_internal() splitting-up the i2c-transfer into
multiple USB bulk packets to honor MAX_PACKET_SIZE.

This splitting up seems to not work and the USBIO expander responds with
a 3 byte answer with flags set 0x0e which includes ERR_FLAG, it seems that
when ERR_FLAG is set only a 3 byte header is returned (no length field).

Modify USBIO_I2C_MAX_XFER_SIZE to avoid the splitting of the i2c-transfer
over multiple USB bulk packets, since the USBIO chip seems to not like
the splitting.

After this change to USBIO_I2C_MAX_XFER_SIZE the code to split transfers
in usbio_transfer_internal() is no longer necessary, remove it.

And also  fix the max payload size check in usbio_bulk_write().