### PR TITLE
ioext: fixed namespace compilation issue

### DIFF
--- a/drivers/gpio/gpio-usbio.c
+++ b/drivers/gpio/gpio-usbio.c
@@ -265,4 +265,8 @@ module_platform_driver(usbio_gpio_driver);
 MODULE_DESCRIPTION("Intel USBIO GPIO driver");
 MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
 MODULE_LICENSE("GPL");
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
+MODULE_IMPORT_NS("USBIO");
+#else
 MODULE_IMPORT_NS(USBIO);
+#endif

--- a/drivers/i2c/busses/i2c-usbio.c
+++ b/drivers/i2c/busses/i2c-usbio.c
@@ -231,4 +231,8 @@ module_platform_driver(usbio_i2c_driver);
 MODULE_DESCRIPTION("Intel USBIO I2C driver");
 MODULE_AUTHOR("Israel Cepeda <israel.a.cepeda.lopez@intel.com>");
 MODULE_LICENSE("GPL");
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
+MODULE_IMPORT_NS("USBIO");
+#else
 MODULE_IMPORT_NS(USBIO);
+#endif

--- a/drivers/usb/misc/usbio.c
+++ b/drivers/usb/misc/usbio.c
@@ -7,6 +7,7 @@
  */
 
 #include "usbio.h"
+#include <linux/version.h>
 
 static struct usbio_device *iobridge;
 
@@ -411,7 +412,11 @@ int usbio_gpio_init(struct ioext_gpio_bank *banks, unsigned int len)
 
 	return iobridge->nr_gpio_banks;
 }
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
+EXPORT_SYMBOL_NS_GPL(usbio_gpio_init, "USBIO");
+#else
 EXPORT_SYMBOL_NS_GPL(usbio_gpio_init, USBIO);
+#endif
 
 int usbio_transfer(u8 type, u8 cmd, const void *obuf, u16 obuf_len,
 		void *ibuf, u16 ibuf_len)
@@ -431,7 +436,11 @@ int usbio_transfer(u8 type, u8 cmd, const void *obuf, u16 obuf_len,
 
 	return ret;
 }
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
+EXPORT_SYMBOL_NS_GPL(usbio_transfer, "USBIO");
+#else
 EXPORT_SYMBOL_NS_GPL(usbio_transfer, USBIO);
+#endif
 
 static int usbio_suspend(struct usb_interface *intf, pm_message_t msg)
 {


### PR DESCRIPTION
Kernel 6.13 and beyond had changed the input
string type for MODULE_IMPORT_NS macro. This
commit will address it for both older and newer
kernels.