### PR TITLE
Fix DKMS version mismatch and Makefile KERNELDIR handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,11 @@ gpio-usbio-y := drivers/gpio/gpio-usbio.o
 obj-m += i2c-usbio.o
 i2c-usbio-y := drivers/i2c/busses/i2c-usbio.o
 
-KERNELRELEASE := $(shell uname -r)
-KDIR := /lib/modules/$(KERNELRELEASE)/build
+KERNELRELEASE ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KERNELRELEASE)/build
+ifdef KERNELDIR
+KDIR := $(KERNELDIR)
+endif
 PWD := $(shell pwd)
 
 ccflags-y += -I$(src)/include/

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="usbio"
-PACKAGE_VERSION="0.2"
+PACKAGE_VERSION="0.3"
 
 MAKE="make -C . KERNELDIR=/lib/modules/${kernelver}/build"
 CLEAN="make -C . clean"


### PR DESCRIPTION
## Summary

- **dkms.conf**: Fix `PACKAGE_VERSION` from `"0.2"` to `"0.3"` to match the actual release version referenced in the README
- **Makefile**: Change `:=` to `?=` for `KERNELRELEASE` and `KDIR`, and add an `ifdef KERNELDIR` block so the `KERNELDIR` variable passed by `dkms.conf` is properly honoured

## Problem

1. The `dkms.conf` registers version `0.2` but the README instructs users to use version `0.3`, causing confusion and DKMS registration mismatches.

2. The Makefile uses unconditional assignment (`:=`) for `KERNELRELEASE` and `KDIR`, which means the `KERNELDIR` variable passed via the DKMS `MAKE` command is silently ignored. This causes DKMS builds to compile against the running kernel rather than the target kernel during kernel upgrades.

## Testing

Tested on Ubuntu 24.04 LTS, kernel 6.17.0-14-generic (HWE):

- Direct build (`make`): 3 modules built successfully
- DKMS-style build (`make KERNELDIR=/lib/modules/6.17.0-14-generic/build`): 3 modules built successfully
- Exact DKMS command (`make -C . KERNELDIR=/lib/modules/6.17.0-14-generic/build`): 3 modules built successfully
- All three modules (usbio, gpio-usbio, i2c-usbio) load correctly and the camera stack functions as expected

Signed-off-by: Achraf Soltani <achraf@achrafsoltani.com>